### PR TITLE
Affiliate documentation 

### DIFF
--- a/Affiliates/Codes.md
+++ b/Affiliates/Codes.md
@@ -1,0 +1,25 @@
+# Get affiliate's subcodes
+
+## Endpoint
+
+`GET https://www.rivalry.gg/api/v1/affiliates/codes`
+
+## Response format
+
+On success, the HTTP status code in the response header is `200` and the response contains the `JSON` data containing affiliate report for a selected time period.
+
+KEY | Value type | Value description
+--- | --- | ---
+id | int | Identifier
+code | string | Code
+
+### Example:
+
+```json
+{
+	"data": {
+		"id": 1,
+		"code": "GreenPanda"
+	}
+}
+```

--- a/Affiliates/Readme.md
+++ b/Affiliates/Readme.md
@@ -16,3 +16,4 @@ Base URL: `https://www.rivalry.gg/api`
 Method | Endpoint | Usage | Returns
 --- | --- | --- | ---
 GET | [`/v1/affiliates/stats`](Stats.md) | Get affiliate report | [affiliate report](../Objects.md#affiliate-report)
+GET | [`/v1/affiliates/codes`](Codes.md) | Get affiliate's subcodes | [affiliate subcodes](../Objects.md#affiliate-subcode)

--- a/Affiliates/Stats.md
+++ b/Affiliates/Stats.md
@@ -6,12 +6,16 @@
 
 ## Query parameters:
 
-Both date parameters are required
+Both date parameters are required. Subcode
 
 KEY | Value | Value description
 --- | --- | ---
 start_date | date (YYYY-MM-DD) | Report period start
 end_date | date (YYYY-MM-DD) | Report period end
+subcode_id | int | Subcode identifier
+
+**Warning**
+When no `subcode_id` is provided, the report will return cumulative results for all users registered with any or no subcodes. However, when `subcode_id` is provided, the returned report will include only results for users registered with that subcode.
 
 ## Response format
 
@@ -28,6 +32,7 @@ amount_deposited | int (USD cents) | Amount deposited in the selected period
 amount_wagered | int (USD cents) | Amount wagered in the selected period
 ggr_revenue | int (USD cents) | Gross gambling revenue
 net_revenue | int (USD cents) | Net affiliate revenue
+?subcode_id | int | Subcode identifier (only when showing statistics for a specific subcode)
 
 ### Example:
 
@@ -41,7 +46,8 @@ net_revenue | int (USD cents) | Net affiliate revenue
 		"amount_deposited": 516000,
 		"amount_wagered": 0,
 		"ggr_revenue": 495700,
-		"net_revenue": 99140
+		"net_revenue": 99140,
+		"subcode_id": null
 	}
 }
 ```

--- a/Matches/Readme.md
+++ b/Matches/Readme.md
@@ -1,5 +1,5 @@
 # Matches
-Endpoints for retrieving information about one or more matches from Rivalry.gg
+Endpoints for retrieving information about one or more matches from [Rivalry.gg](https://www.rivalry.gg/)
 
 Base URL: `https://www.rivalry.gg/api`
 

--- a/Objects.md
+++ b/Objects.md
@@ -1,6 +1,6 @@
 # Objects
 
-A full list of the objects returned by the endpoints of the Rivalry.gg API.
+A full list of the objects returned by the endpoints of the [Rivalry.gg](https://www.rivalry.gg/) API.
 
 A key starting with `?` represents data that is not included in all endpoints. For reference what the endpoints include see [available endpoints](../).
 
@@ -67,3 +67,11 @@ amount_deposited | int (USD cents) | Amount deposited in the selected period
 amount_wagered | int (USD cents) | Amount wagered in the selected period
 ggr_revenue | int (USD cents) | Gross gambling revenue
 net_revenue | int (USD cents) | Net affiliate revenue
+?subcode_id | int | Subcode identifier (only when showing statistics for a specific subcode)
+
+## Affiliate subcode
+
+KEY | Value type | Value description
+--- | --- | ---
+id | int | Identifier
+code | string | Code

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-# Rivalry.gg API
+# [Rivalry.gg](https://www.rivalry.gg/) API
 
 ## Available endpoints
 
@@ -10,14 +10,16 @@ GET | [`/v1/matches`](Matches/Index.md) | Get several matches | matches
 GET | [`/v1/matches/{id}`](Matches/Show.md) | Get a match | match
 GET | [`/v1/tournaments`](Tournaments/Index.md) | Get several tournaments | tournaments
 GET | [`/v1/tournaments/{id}`](Tournaments/Show.md) | Get a tournament | tournament
+GET | [`/v1/affiliates/stats`](Affiliates/Stats.md) | Get affiliate's report | affiliate report
+GET | [`/v1/affiliates/codes`](Affiliates/Codes.md) | Get affiliate's subcodes | affiliate subcodes
 
 ## Requests
 
-The Rivalry.gg API is based on REST principles. Data resources are retrieved via standard HTTPS GET requests in UTF-8 format to an API endpoint.
+The [Rivalry.gg](https://www.rivalry.gg/) API is based on REST principles. Data resources are retrieved via standard HTTPS GET requests in UTF-8 format to an API endpoint.
 
 ## Responses
 
-Rivalry.gg API returns all successful response data as a JSON object with HTTP status code `200`.
+[Rivalry.gg](https://www.rivalry.gg/) API returns all successful response data as a JSON object with HTTP status code `200`.
 
 The requested data is always wrapped in a `data` field:
 

--- a/Tournaments/Readme.md
+++ b/Tournaments/Readme.md
@@ -1,5 +1,5 @@
 # Tournaments
-Endpoints for retrieving information about one or more tournaments from Rivalry.gg
+Endpoints for retrieving information about one or more tournaments from [Rivalry.gg](https://www.rivalry.gg/)
 
 Base URL: `https://www.rivalry.gg/api`
 


### PR DESCRIPTION
PR adds:
* documentation for new affiliate subcodes endpoint
* documentation for new `subcode_id` parameter in `affiliates/stats` endpoint
* links to [https://www.rivalry.gg/](https://www.rivalry.gg/)